### PR TITLE
001 Update NPM publish stable workflow

### DIFF
--- a/npm-publish-stable.yaml
+++ b/npm-publish-stable.yaml
@@ -1,12 +1,11 @@
 name: NPM Publish Stable
 
 on:
-  push:
-    branches: 
-      - main
   pull_request:
-    branches: 
-      - main
+    types:
+      -closed
+    branches:
+      main
 
 concurrency:
   group: npm-publish


### PR DESCRIPTION
Update the npm-publish-stable workflow so that it does not run on commits made to PR branches.
